### PR TITLE
Allows C++ libraries to be loaded

### DIFF
--- a/lua-5.2.4/src/lauxlib.c
+++ b/lua-5.2.4/src/lauxlib.c
@@ -943,7 +943,7 @@ LUALIB_API lua_State *luaL_newstate (void) {
 
 LUALIB_API void luaL_checkversion_ (lua_State *L, lua_Number ver) {
   const lua_Number *v = lua_version(L);
-  if (v != lua_version(NULL))
+  if (*v != *lua_version(NULL))
     luaL_error(L, "multiple Lua VMs detected");
   else if (*v != ver)
     luaL_error(L, "version mismatch: app. needs %f, Lua core provides %f",


### PR DESCRIPTION
This change allows C++ libraries to be loaded, even though they have their own copy of the Lua 5.2 VM. This change is similar to official changes in Lua 5.3 and 5.4