### PR TITLE
Remove tinyxml2 extra code

### DIFF
--- a/tinyxml2/tinyxml2.cpp
+++ b/tinyxml2/tinyxml2.cpp
@@ -1088,7 +1088,7 @@ char* XMLNode::ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr )
         StrPair endTag;
         p = node->ParseDeep( p, &endTag, curLineNumPtr );
         if ( !p ) {
-            DeleteNode( node );
+            _document->DeleteNode( node );
             if ( !_document->Error() ) {
                 _document->SetError( XML_ERROR_PARSING, initialLineNum, 0);
             }
@@ -1121,7 +1121,7 @@ char* XMLNode::ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr )
             }
             if ( !wellLocated ) {
                 _document->SetError( XML_ERROR_PARSING_DECLARATION, initialLineNum, "XMLDeclaration value=%s", decl->Value());
-                DeleteNode( node );
+                _document->DeleteNode( node );
                 break;
             }
         }
@@ -1156,7 +1156,7 @@ char* XMLNode::ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr )
             }
             if ( mismatch ) {
                 _document->SetError( XML_ERROR_MISMATCHED_ELEMENT, initialLineNum, "XMLElement name=%s", ele->Name());
-                DeleteNode( node );
+                _document->DeleteNode( node );
                 break;
             }
         }

--- a/tinyxml2/tinyxml2.cpp
+++ b/tinyxml2/tinyxml2.cpp
@@ -1088,7 +1088,7 @@ char* XMLNode::ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr )
         StrPair endTag;
         p = node->ParseDeep( p, &endTag, curLineNumPtr );
         if ( !p ) {
-            _document->DeleteNode( node );
+            DeleteNode( node );
             if ( !_document->Error() ) {
                 _document->SetError( XML_ERROR_PARSING, initialLineNum, 0);
             }
@@ -1121,7 +1121,7 @@ char* XMLNode::ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr )
             }
             if ( !wellLocated ) {
                 _document->SetError( XML_ERROR_PARSING_DECLARATION, initialLineNum, "XMLDeclaration value=%s", decl->Value());
-                _document->DeleteNode( node );
+                DeleteNode( node );
                 break;
             }
         }
@@ -1156,7 +1156,7 @@ char* XMLNode::ParseDeep( char* p, StrPair* parentEndTag, int* curLineNumPtr )
             }
             if ( mismatch ) {
                 _document->SetError( XML_ERROR_MISMATCHED_ELEMENT, initialLineNum, "XMLElement name=%s", ele->Name());
-                _document->DeleteNode( node );
+                DeleteNode( node );
                 break;
             }
         }
@@ -2181,28 +2181,6 @@ XMLDocument::XMLDocument( bool processEntities, Whitespace whitespaceMode ) :
     _document = this;
 }
 
-// Finale Lua change: Lua-friendly constructor
-XMLDocument::XMLDocument() :
-    XMLNode( 0 ),
-    _writeBOM( false ),
-    _processEntities( true ),
-    _errorID(XML_SUCCESS),
-    _whitespaceMode( PRESERVE_WHITESPACE ),
-    _errorStr(),
-    _errorLineNum( 0 ),
-    _charBuffer( 0 ),
-    _parseCurLineNum( 0 ),
-    _parsingDepth(0),
-    _unlinked(),
-    _elementPool(),
-    _attributePool(),
-    _textPool(),
-    _commentPool()
-{
-    // avoid VC++ C4355 warning about 'this' in initializer list (C4355 is off by default in VS2012+)
-    _document = this;
-}
-
 
 XMLDocument::~XMLDocument()
 {
@@ -2636,35 +2614,6 @@ XMLPrinter::XMLPrinter( FILE* file, bool compact, int depth ) :
     _restrictedEntityFlag[static_cast<unsigned char>('&')] = true;
     _restrictedEntityFlag[static_cast<unsigned char>('<')] = true;
     _restrictedEntityFlag[static_cast<unsigned char>('>')] = true;	// not required, but consistency is nice
-    _buffer.Push( 0 );
-}
-
-// Finale Lua change: Lua-friendly constructor
-
-XMLPrinter::XMLPrinter() :
-    _elementJustOpened( false ),
-    _stack(),
-    _firstElement( true ),
-    _fp( 0 ),
-    _depth( 0 ),
-    _textDepth( -1 ),
-    _processEntities( true ),
-    _compactMode( false ),
-    _buffer()
-{
-    for( int i=0; i<ENTITY_RANGE; ++i ) {
-        _entityFlag[i] = false;
-        _restrictedEntityFlag[i] = false;
-    }
-    for( int i=0; i<NUM_ENTITIES; ++i ) {
-        const char entityValue = entities[i].value;
-        const unsigned char flagIndex = static_cast<unsigned char>(entityValue);
-        TIXMLASSERT( flagIndex < ENTITY_RANGE );
-        _entityFlag[flagIndex] = true;
-    }
-    _restrictedEntityFlag[static_cast<unsigned char>('&')] = true;
-    _restrictedEntityFlag[static_cast<unsigned char>('<')] = true;
-    _restrictedEntityFlag[static_cast<unsigned char>('>')] = true;    // not required, but consistency is nice
     _buffer.Push( 0 );
 }
 

--- a/tinyxml2/tinyxml2.cpp
+++ b/tinyxml2/tinyxml2.cpp
@@ -22,6 +22,10 @@ distribution.
 */
 
 #include "tinyxml2.h"
+#ifdef _WIN32
+// Finale change: need UTF-8/UTF-16 conversion
+#include <string>
+#endif // _WIN32
 
 #include <new>		// yes, this one new style header, is in the Android SDK.
 #if defined(ANDROID_NDK) || defined(__BORLANDC__) || defined(__QNXNTO__)

--- a/tinyxml2/tinyxml2.cpp
+++ b/tinyxml2/tinyxml2.cpp
@@ -2343,16 +2343,14 @@ void XMLDocument::DeleteNode( XMLNode* node )	{
 // Finale change: convert string to wchar_t for Windows
 inline std::basic_string<wchar_t> charToWCHAR(const char* inpstr)
 {
-    std::basic_string<wchar_t> result();
+    std::basic_string<wchar_t> result;
     UINT cp = CP_UTF8;
     int size = MultiByteToWideChar(cp, MB_ERR_INVALID_CHARS, inpstr, -1, nullptr, 0) - 1; // remove null-terminator
-    if (size <= 0)
-    {
+    if (size <= 0) {
         cp = CP_ACP;
         size = MultiByteToWideChar(cp, 0, inpstr, -1, nullptr, 0) - 1;
     }
-    if (size > 0)
-    {
+    if (size > 0) {
         result.resize(size);
         MultiByteToWideChar(cp, 0, inpstr, -1, result.data(), size);
     }

--- a/tinyxml2/tinyxml2.h
+++ b/tinyxml2/tinyxml2.h
@@ -112,7 +112,7 @@ static const int TIXML2_PATCH_VERSION = 0;
 // system, and the capacity of the stack. On the other hand, it's a trivial
 // attack that can result from ill, malicious, or even correctly formed XML,
 // so there needs to be a limit in place.
-static const int TINYXML2_MAX_ELEMENT_DEPTH = 100;
+static const int TINYXML2_MAX_ELEMENT_DEPTH = 500;
 
 namespace tinyxml2
 {
@@ -375,7 +375,7 @@ public:
     virtual void* Alloc() {
         if ( !_root ) {
             // Need a new block.
-            Block* block = new Block();
+            Block* block = new Block;
             _blockPtrs.Push( block );
 
             Item* blockItems = block->items;

--- a/tinyxml2/tinyxml2.h
+++ b/tinyxml2/tinyxml2.h
@@ -112,7 +112,7 @@ static const int TIXML2_PATCH_VERSION = 0;
 // system, and the capacity of the stack. On the other hand, it's a trivial
 // attack that can result from ill, malicious, or even correctly formed XML,
 // so there needs to be a limit in place.
-static const int TINYXML2_MAX_ELEMENT_DEPTH = 500;
+static const int TINYXML2_MAX_ELEMENT_DEPTH = 100;
 
 namespace tinyxml2
 {
@@ -375,7 +375,7 @@ public:
     virtual void* Alloc() {
         if ( !_root ) {
             // Need a new block.
-            Block* block = new Block;
+            Block* block = new Block();
             _blockPtrs.Push( block );
 
             Item* blockItems = block->items;

--- a/tinyxml2/tinyxml2.h
+++ b/tinyxml2/tinyxml2.h
@@ -1725,9 +1725,7 @@ class TINYXML2_LIB XMLDocument : public XMLNode
     friend class XMLUnknown;
 public:
     /// constructor
-    XMLDocument( bool processEntities, Whitespace whitespaceMode = PRESERVE_WHITESPACE );
-// Finale Lua change: Lua-friendly constructor
-    XMLDocument();
+    XMLDocument( bool processEntities = true, Whitespace whitespaceMode = PRESERVE_WHITESPACE );
     ~XMLDocument();
 
     virtual XMLDocument* ToDocument()				{
@@ -2245,11 +2243,8 @@ public:
     	If 'compact' is set to true, then output is created
     	with only required whitespace and newlines.
     */
-    XMLPrinter( FILE* file, bool compact = false, int depth = 0 );
+    XMLPrinter( FILE* file=0, bool compact = false, int depth = 0 );
     virtual ~XMLPrinter()	{}
-    
-    // Finale Lua change: Lua-friendly constructor
-    XMLPrinter();
 
     /** If streaming, write the BOM and declaration. */
     void PushHeader( bool writeBOM, bool writeDeclaration );


### PR DESCRIPTION
This PR gets us as close as possible to vanilla tinyxml2. The only remaining change is using wfopen on Win. There is no longer a dependency on the JW PDK Framework.